### PR TITLE
Update rg_replace.sh

### DIFF
--- a/useful_scripts/rg_replace.sh
+++ b/useful_scripts/rg_replace.sh
@@ -24,6 +24,14 @@
 #   3. `gs_rgr`
 #   4. `gs_rg_replace`
 
+# SIMPLE FISH IMPLEMENTATION (not using bins)
+# essentially we create a function that executes rg_replace.sh (named rgr.sh in my config) 
+
+# function rgr
+#   set -l DOOTFILE_LOC ~/Documents/dotFiles/ # replace to the current location of rg_replace.sh
+#   bash "$DOOTFILE_LOC"/rgr.sh "$argv"
+# end
+
 # References:
 # 1. How to use `rg` to do an in-place replacement in a **single file** at a time:
 #    https://learnbyexample.github.io/substitution-with-ripgrep/#in-place-workaround

--- a/useful_scripts/rg_replace.sh
+++ b/useful_scripts/rg_replace.sh
@@ -24,12 +24,13 @@
 #   3. `gs_rgr`
 #   4. `gs_rg_replace`
 
-# SIMPLE FISH IMPLEMENTATION (not using bins)
-# essentially we create a function that executes rg_replace.sh (named rgr.sh in my config) 
+# SIMPLE FISH IMPLEMENTATION (not using binaries)
+# essentially we create a function that executes rg_replace.sh (named rgr.sh in my config)
+# NOTE: must be placed in your fish config.
 
 # function rgr
-#   set -l DOOTFILE_LOC ~/Documents/dotFiles/ # replace to the current location of rg_replace.sh
-#   bash "$DOOTFILE_LOC"/rgr.sh "$argv"
+#   set -l DOTFILE_LOC ~/Documents/dotFiles/ # replace the path to the current location of rg_replace.sh
+#   bash "$DOTFILE_LOC"/rgr.sh "$argv"
 # end
 
 # References:


### PR DESCRIPTION
Added a quick note on how to use rgr on fish without using binaries. Essentially point to the local rg_replace.sh file. I am sure they are cleverer implementation but its simple enough.