### PR TITLE
Add --no-ext-diff to git-diffc

### DIFF
--- a/useful_scripts/git-diffc.sh
+++ b/useful_scripts/git-diffc.sh
@@ -63,7 +63,7 @@
 
 # See all of my comments in git-diffn.sh above to help you decipher all of this goobly-gock.
 # See also here: https://stackoverflow.com/questions/18810623/git-diff-to-show-only-lines-that-have-been-modified/62009746#62009746
-git diff --color=always "$@" | awk '
+git diff --no-ext-diff --color=always "$@" | awk '
 # 1. Match and then skip "--- a/" and "+++ b/" lines
 /^(\033\[(([0-9]{1,2};?){1,10})m)?(--- a\/|\+\+\+ b\/)/ {
     next 


### PR DESCRIPTION
The `--no-ext-diff` flag is necessary to ensure STDOUT behavior for `git diff` for people who, like msyelf, have `git diff` configured to use an external tool by default:

```
$ grep -B1 external ~/.gitconfig
[diff]
	external = ~/bin/araxisgitdiff
```

NBD if you don't want to merge this; I've made the change for my local copy and don't anticipate it coming up again.  Thanks for the useful script!