### PR TITLE
Fix data column printing in size_mcu.sh

### DIFF
--- a/useful_scripts/size_mcu.sh
+++ b/useful_scripts/size_mcu.sh
@@ -338,8 +338,8 @@ print_size_info() {
 
         text=$(echo "$data" | awk '{print $1}')
         rodata=$(echo "$data" | awk '{print $2}')
-        data=$(echo "$data" | awk '{print $3}')
         bss=$(echo "$data" | awk '{print $4}')
+        data=$(echo "$data" | awk '{print $3}')
 
         flash=$(($text + $rodata + $data))
         sram=$(($bss + $data))
@@ -361,8 +361,8 @@ print_size_info() {
         fi
 
         text=$(echo "$data" | awk '{print $1}')
-        data=$(echo "$data" | awk '{print $2}')
         bss=$(echo "$data" | awk '{print $3}')
+        data=$(echo "$data" | awk '{print $2}')
 
         flash=$(($text + $data))
         sram=$(($bss + $data))


### PR DESCRIPTION
Creating a new variable named data overwrites the $data variable containing the output of the size command. If we evaluate bss before data, this issue is mitigated as the output is not used afterwards 🙂

For the rest, really useful script, thanks!